### PR TITLE
add logrecorder support for log4j2

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ A collection of test-related utility libraries.
 
 - Junit 5 extension for recording Logback loggers
 
+## logrecorder-log4j
+
+- Junit 5 extension for recording [Log4j 2](http://logging.apache.org/log4j/2.x/index.html) loggers
+
 ### Licensing
 TestUtils is licensed under [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt).
 

--- a/logrecorder/logrecorder-log4j/pom.xml
+++ b/logrecorder/logrecorder-log4j/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>info.novatec.testit</groupId>
+		<artifactId>logrecorder</artifactId>
+		<version>1.1.0-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>logrecorder-log4j</artifactId>
+	<packaging>jar</packaging>
+	<name>testIT | TestUtils - Log Recorder Log4J</name>
+
+	<dependencies>
+		<dependency>
+			<groupId>info.novatec.testit</groupId>
+			<artifactId>logrecorder-api</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>info.novatec.testit</groupId>
+			<artifactId>logrecorder-assertions</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-core</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-source-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.jetbrains.kotlin</groupId>
+				<artifactId>kotlin-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.jetbrains.dokka</groupId>
+				<artifactId>dokka-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/logrecorder/logrecorder-log4j/src/main/kotlin/info/novatec/testit/logrecorder/log4j/CallbackAppender.kt
+++ b/logrecorder/logrecorder-log4j/src/main/kotlin/info/novatec/testit/logrecorder/log4j/CallbackAppender.kt
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package info.novatec.testit.logrecorder.log4j
+
+import org.apache.logging.log4j.core.Appender
+import org.apache.logging.log4j.core.Core
+import org.apache.logging.log4j.core.Filter
+import org.apache.logging.log4j.core.Layout
+import org.apache.logging.log4j.core.LogEvent
+import org.apache.logging.log4j.core.appender.AbstractAppender
+import org.apache.logging.log4j.core.config.plugins.Plugin
+
+@Plugin(
+    name = "CallbackAppender",
+    category = Core.CATEGORY_NAME,
+    elementType = Appender.ELEMENT_TYPE
+)
+internal class CallbackAppender(
+    name: String,
+    filter: Filter?,
+    layout: Layout<String>?,
+    private val eventConsumer: (LogEvent) -> Unit
+) : AbstractAppender(name, filter, layout, false, null) {
+
+    override fun append(event: LogEvent) {
+        eventConsumer(event)
+    }
+
+}

--- a/logrecorder/logrecorder-log4j/src/main/kotlin/info/novatec/testit/logrecorder/log4j/Log4jLogRecord.kt
+++ b/logrecorder/logrecorder-log4j/src/main/kotlin/info/novatec/testit/logrecorder/log4j/Log4jLogRecord.kt
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package info.novatec.testit.logrecorder.log4j
+
+import info.novatec.testit.logrecorder.api.LogEntry
+import info.novatec.testit.logrecorder.api.LogLevel
+import info.novatec.testit.logrecorder.api.LogRecord
+import org.apache.logging.log4j.Level
+import org.apache.logging.log4j.core.LogEvent
+
+internal class Log4jLogRecord : LogRecord {
+
+    private val recordedLogEntries: MutableList<LogEntry> = mutableListOf()
+
+    override val entries: List<LogEntry>
+        get() = ArrayList(recordedLogEntries)
+
+    fun record(value: LogEvent) {
+        val logEntry = LogEntry(
+            logger = value.loggerName,
+            level = when (value.level) {
+                Level.TRACE -> LogLevel.TRACE
+                Level.DEBUG -> LogLevel.DEBUG
+                Level.INFO -> LogLevel.INFO
+                Level.WARN -> LogLevel.WARN
+                Level.ERROR -> LogLevel.ERROR
+                else -> LogLevel.UNKNOWN
+            },
+            message = value.message.formattedMessage
+        )
+        recordedLogEntries.add(logEntry)
+    }
+
+}

--- a/logrecorder/logrecorder-log4j/src/main/kotlin/info/novatec/testit/logrecorder/log4j/Log4jLogRecorder.kt
+++ b/logrecorder/logrecorder-log4j/src/main/kotlin/info/novatec/testit/logrecorder/log4j/Log4jLogRecorder.kt
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package info.novatec.testit.logrecorder.log4j
+
+import org.apache.logging.log4j.Level
+import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.Logger
+import org.apache.logging.log4j.core.LoggerContext
+import org.apache.logging.log4j.core.config.AppenderRef
+import org.apache.logging.log4j.core.config.LoggerConfig
+import org.apache.logging.log4j.core.layout.PatternLayout
+
+internal class Log4jLogRecorder(
+    logger: Logger,
+    logRecord: Log4jLogRecord
+) {
+    private val loggerName = logger.name
+    private val originalLoggerLevel = logger.level
+
+    private val loggerContext = LogManager.getContext(false) as LoggerContext
+    private val configuration = loggerContext.configuration
+    private var newCreatedLogger = false
+
+    private val appenderName = "TemporaryLogAppender-${System.nanoTime()}"
+    private val appender = CallbackAppender(appenderName, null, PatternLayout.createDefaultLayout(), logRecord::record)
+    private val appenderRef = AppenderRef.createAppenderRef(appenderName, null, null)
+    private val appenderRefs = arrayOf(appenderRef)
+
+
+    fun start() {
+        appender.start()
+        configuration.addAppender(appender)
+        val loggerConfig = getLoggerConfig()
+        if (!loggerConfig.name.equals(loggerName)) {
+            val newLoggerConfig = LoggerConfig.createLogger(
+                false,
+                Level.ALL,
+                loggerName,
+                "true",
+                appenderRefs,
+                null,
+                configuration,
+                null
+            )
+            newLoggerConfig.addAppender(appender, null, null)
+            configuration.addLogger(loggerName, newLoggerConfig)
+            newCreatedLogger = true
+        } else {
+            loggerConfig.appenderRefs.add(appenderRef)
+        }
+        updateLoggerContext()
+    }
+
+    fun stop() {
+        appender.stop()
+        configuration.appenders.remove(appenderName)
+        if (newCreatedLogger) {
+            configuration.removeLogger(loggerName)
+        } else {
+            val loggerConfig = getLoggerConfig()
+            loggerConfig.appenderRefs.remove(appenderRef)
+            loggerConfig.level = originalLoggerLevel
+        }
+        updateLoggerContext()
+    }
+
+    private fun getLoggerConfig(): LoggerConfig = configuration.getLoggerConfig(loggerName)
+
+    private fun updateLoggerContext() {
+        loggerContext.updateLoggers()
+    }
+
+}

--- a/logrecorder/logrecorder-log4j/src/main/kotlin/info/novatec/testit/logrecorder/log4j/junit5/Log4jRecorderExtension.kt
+++ b/logrecorder/logrecorder-log4j/src/main/kotlin/info/novatec/testit/logrecorder/log4j/junit5/Log4jRecorderExtension.kt
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package info.novatec.testit.logrecorder.log4j.junit5
+
+import info.novatec.testit.logrecorder.api.LogRecord
+import info.novatec.testit.logrecorder.log4j.Log4jLogRecord
+import info.novatec.testit.logrecorder.log4j.Log4jLogRecorder
+import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.Logger
+import org.junit.jupiter.api.extension.AfterTestExecutionCallback
+import org.junit.jupiter.api.extension.BeforeTestExecutionCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+import org.junit.jupiter.api.extension.ParameterContext
+import org.junit.jupiter.api.extension.ParameterResolver
+
+/**
+ * This extension will record the loggers specified by a [RecordLoggers] annotation and inject the [LogRecord]
+ * as a parameter into the test method.
+ *
+ * Recording a logger will set its log level to [org.apache.logging.log4j.Level.ALL] for the duration of the test. After the
+ * test was executed, the log level will be restored to whatever it was before.
+ *
+ * @see RecordLoggers
+ * @see LogRecord
+ * @since 1.1
+ */
+class Log4jRecorderExtension : BeforeTestExecutionCallback, AfterTestExecutionCallback,
+    ParameterResolver {
+
+    private val namespace = ExtensionContext.Namespace.create(javaClass)
+
+    override fun supportsParameter(parameterContext: ParameterContext, extensionContext: ExtensionContext): Boolean {
+        return LogRecord::class.java == parameterContext.parameter.type
+    }
+
+    override fun resolveParameter(parameterContext: ParameterContext, extensionContext: ExtensionContext): Any {
+        return extensionContext.logRecord
+    }
+
+    override fun beforeTestExecution(context: ExtensionContext) {
+        val annotation = context.requiredTestMethod.getAnnotation(RecordLoggers::class.java)
+            ?: error("no @RecordLoggers annotation found on test method!")
+        val fromClasses = annotation.value.map { LogManager.getLogger(it.java) }
+        val fromNames = annotation.names.map { LogManager.getLogger(it) }
+
+        val logRecord = Log4jLogRecord()
+        context.logRecord = logRecord
+
+        val recorders = (fromClasses + fromNames)
+            .distinct()
+            .map { it as Logger }
+            .map { Log4jLogRecorder(it, logRecord) }
+            .onEach { it.start() }
+        context.recorders = recorders
+    }
+
+    override fun afterTestExecution(context: ExtensionContext) {
+        context.recorders.forEach { it.stop() }
+    }
+
+    private var ExtensionContext.recorders: List<Log4jLogRecorder>
+        get() = store.get("log-recorders") as List<Log4jLogRecorder>
+        set(value) = store.put("log-recorders", value)
+
+    private var ExtensionContext.logRecord: Log4jLogRecord
+        get() = store.get("log-record", Log4jLogRecord::class.java)
+        set(value) = store.put("log-record", value)
+
+    private val ExtensionContext.store: ExtensionContext.Store
+        get() = getStore(namespace)
+
+}

--- a/logrecorder/logrecorder-log4j/src/main/kotlin/info/novatec/testit/logrecorder/log4j/junit5/RecordLoggers.kt
+++ b/logrecorder/logrecorder-log4j/src/main/kotlin/info/novatec/testit/logrecorder/log4j/junit5/RecordLoggers.kt
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package info.novatec.testit.logrecorder.log4j.junit5
+
+import org.junit.jupiter.api.extension.ExtendWith
+import kotlin.reflect.KClass
+
+/**
+ * Annotating any test method with this annotation will start the recording of
+ * log messages while the test method is executed.
+ *
+ * Only those loggers configured with this annotation - either by it's class or
+ * name - will be recorded! Multiple loggers can be set by either method and
+ * combinations between class and explicit names are possible as well.
+ *
+ * @see value
+ * @see names
+ * @since 1.0
+ */
+@Retention
+@Target(AnnotationTarget.FUNCTION)
+@ExtendWith(Log4jRecorderExtension::class)
+annotation class RecordLoggers(
+
+    /**
+     * Classes who's name should be used to identify loggers to record.
+     */
+    vararg val value: KClass<*> = [],
+
+    /**
+     * Names of loggers to record.
+     */
+    val names: Array<String> = []
+
+)

--- a/logrecorder/logrecorder-log4j/src/test/kotlin/info/novatec/testit/logrecorder/log4j/junit5/Log4jRecorderExtensionTest.kt
+++ b/logrecorder/logrecorder-log4j/src/test/kotlin/info/novatec/testit/logrecorder/log4j/junit5/Log4jRecorderExtensionTest.kt
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package info.novatec.testit.logrecorder.log4j.junit5
+
+import info.novatec.testit.logrecorder.api.LogEntry
+import info.novatec.testit.logrecorder.api.LogLevel
+import info.novatec.testit.logrecorder.api.LogRecord
+import org.apache.logging.log4j.LogManager
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class Log4JRecorderExtensionTest {
+
+    private val customLogger = LogManager.getLogger("custom-logger")
+
+    private val testServiceA = TestServiceA()
+    private val testServiceB = TestServiceB()
+
+    @BeforeEach
+    fun logSomethingBeforeTest() {
+        testServiceA.logSomething()
+        testServiceB.logSomething()
+    }
+
+    @RecordLoggers(TestServiceA::class, TestServiceB::class, names = ["custom-logger"])
+    @Test
+    fun `extension is registered and log messages are recorded`(log: LogRecord) {
+        assertThat(log.entries).isEmpty()
+
+        testServiceA.logSomething()
+        assertThat(log.entries).containsExactly(
+            LogEntry(LogRecord.logger(TestServiceA::class), LogLevel.TRACE, "trace message a"),
+            LogEntry(LogRecord.logger(TestServiceA::class), LogLevel.DEBUG, "debug message a"),
+            LogEntry(LogRecord.logger(TestServiceA::class), LogLevel.INFO, "info message a"),
+            LogEntry(LogRecord.logger(TestServiceA::class), LogLevel.WARN, "warn message a"),
+            LogEntry(LogRecord.logger(TestServiceA::class), LogLevel.ERROR, "error message a")
+        )
+
+        testServiceB.logSomething()
+        assertThat(log.entries).containsExactly(
+            LogEntry(LogRecord.logger(TestServiceA::class), LogLevel.TRACE, "trace message a"),
+            LogEntry(LogRecord.logger(TestServiceA::class), LogLevel.DEBUG, "debug message a"),
+            LogEntry(LogRecord.logger(TestServiceA::class), LogLevel.INFO, "info message a"),
+            LogEntry(LogRecord.logger(TestServiceA::class), LogLevel.WARN, "warn message a"),
+            LogEntry(LogRecord.logger(TestServiceA::class), LogLevel.ERROR, "error message a"),
+
+            LogEntry(LogRecord.logger(TestServiceB::class), LogLevel.TRACE, "trace message b"),
+            LogEntry(LogRecord.logger(TestServiceB::class), LogLevel.DEBUG, "debug message b"),
+            LogEntry(LogRecord.logger(TestServiceB::class), LogLevel.INFO, "info message b"),
+            LogEntry(LogRecord.logger(TestServiceB::class), LogLevel.WARN, "warn message b"),
+            LogEntry(LogRecord.logger(TestServiceB::class), LogLevel.ERROR, "error message b")
+        )
+
+        customLogger.trace("trace message c")
+        customLogger.debug("debug message c")
+        customLogger.info("info message c")
+        customLogger.warn("warn message c")
+        customLogger.error("error message c")
+
+        assertThat(log.entries).containsExactly(
+            LogEntry(LogRecord.logger(TestServiceA::class), LogLevel.TRACE, "trace message a"),
+            LogEntry(LogRecord.logger(TestServiceA::class), LogLevel.DEBUG, "debug message a"),
+            LogEntry(LogRecord.logger(TestServiceA::class), LogLevel.INFO, "info message a"),
+            LogEntry(LogRecord.logger(TestServiceA::class), LogLevel.WARN, "warn message a"),
+            LogEntry(LogRecord.logger(TestServiceA::class), LogLevel.ERROR, "error message a"),
+
+            LogEntry(LogRecord.logger(TestServiceB::class), LogLevel.TRACE, "trace message b"),
+            LogEntry(LogRecord.logger(TestServiceB::class), LogLevel.DEBUG, "debug message b"),
+            LogEntry(LogRecord.logger(TestServiceB::class), LogLevel.INFO, "info message b"),
+            LogEntry(LogRecord.logger(TestServiceB::class), LogLevel.WARN, "warn message b"),
+            LogEntry(LogRecord.logger(TestServiceB::class), LogLevel.ERROR, "error message b"),
+
+            LogEntry("custom-logger", LogLevel.TRACE, "trace message c"),
+            LogEntry("custom-logger", LogLevel.DEBUG, "debug message c"),
+            LogEntry("custom-logger", LogLevel.INFO, "info message c"),
+            LogEntry("custom-logger", LogLevel.WARN, "warn message c"),
+            LogEntry("custom-logger", LogLevel.ERROR, "error message c")
+        )
+    }
+
+    @RecordLoggers(TestServiceA::class)
+    @Test
+    fun `extension is registered and log messages are recorded from ServiceA`(log: LogRecord) {
+        assertThat(log.entries).isEmpty()
+
+        testServiceA.logSomething()
+        assertThat(log.entries).containsExactly(
+            LogEntry(LogRecord.logger(TestServiceA::class), LogLevel.TRACE, "trace message a"),
+            LogEntry(LogRecord.logger(TestServiceA::class), LogLevel.DEBUG, "debug message a"),
+            LogEntry(LogRecord.logger(TestServiceA::class), LogLevel.INFO, "info message a"),
+            LogEntry(LogRecord.logger(TestServiceA::class), LogLevel.WARN, "warn message a"),
+            LogEntry(LogRecord.logger(TestServiceA::class), LogLevel.ERROR, "error message a")
+        )
+
+        testServiceB.logSomething()
+        assertThat(log.entries).containsExactly(
+            LogEntry(LogRecord.logger(TestServiceA::class), LogLevel.TRACE, "trace message a"),
+            LogEntry(LogRecord.logger(TestServiceA::class), LogLevel.DEBUG, "debug message a"),
+            LogEntry(LogRecord.logger(TestServiceA::class), LogLevel.INFO, "info message a"),
+            LogEntry(LogRecord.logger(TestServiceA::class), LogLevel.WARN, "warn message a"),
+            LogEntry(LogRecord.logger(TestServiceA::class), LogLevel.ERROR, "error message a")
+        )
+
+        customLogger.trace("trace message c")
+        customLogger.debug("debug message c")
+        customLogger.info("info message c")
+        customLogger.warn("warn message c")
+        customLogger.error("error message c")
+
+        assertThat(log.entries).containsExactly(
+            LogEntry(LogRecord.logger(TestServiceA::class), LogLevel.TRACE, "trace message a"),
+            LogEntry(LogRecord.logger(TestServiceA::class), LogLevel.DEBUG, "debug message a"),
+            LogEntry(LogRecord.logger(TestServiceA::class), LogLevel.INFO, "info message a"),
+            LogEntry(LogRecord.logger(TestServiceA::class), LogLevel.WARN, "warn message a"),
+            LogEntry(LogRecord.logger(TestServiceA::class), LogLevel.ERROR, "error message a")
+        )
+    }
+
+}
+
+class TestServiceA {
+    private val log = LogManager.getLogger(TestServiceA::class.java)
+    fun logSomething() {
+        log.trace("trace message a")
+        log.debug("debug message a")
+        log.info("info message a")
+        log.warn("warn message a")
+        log.error("error message a")
+    }
+}
+
+class TestServiceB {
+    private val log = LogManager.getLogger(TestServiceB::class.java)
+    fun logSomething() {
+        log.trace("trace message b")
+        log.debug("debug message b")
+        log.info("info message b")
+        log.warn("warn message b")
+        log.error("error message b")
+    }
+}

--- a/logrecorder/logrecorder-log4j/src/test/resources/log4j2-test.xml
+++ b/logrecorder/logrecorder-log4j/src/test/resources/log4j2-test.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <Logger name="info.novatec.testit.logrecorder.logback.junit5.TestServiceB" level="debug" additivity="false">
+      <AppenderRef ref="Console"/>
+    </Logger>
+    <Root level="info">
+      <AppenderRef ref="Console"/>
+    </Root>
+  </Loggers>
+</Configuration>

--- a/logrecorder/logrecorder-logback/src/test/kotlin/info/novatec/testit/logrecorder/logback/junit5/LogbackRecorderExtensionTest.kt
+++ b/logrecorder/logrecorder-logback/src/test/kotlin/info/novatec/testit/logrecorder/logback/junit5/LogbackRecorderExtensionTest.kt
@@ -76,6 +76,43 @@ internal class LogbackRecorderExtensionTest {
         )
     }
 
+    @RecordLoggers(TestServiceA::class)
+    @Test fun `extension is registered and log messages are recorded only for TestServiceA`(log: LogRecord) {
+        assertThat(log.entries).isEmpty()
+
+        testServiceA.logSomething()
+        assertThat(log.entries).containsExactly(
+            LogEntry(logger(TestServiceA::class), LogLevel.TRACE, "trace message a"),
+            LogEntry(logger(TestServiceA::class), LogLevel.DEBUG, "debug message a"),
+            LogEntry(logger(TestServiceA::class), LogLevel.INFO, "info message a"),
+            LogEntry(logger(TestServiceA::class), LogLevel.WARN, "warn message a"),
+            LogEntry(logger(TestServiceA::class), LogLevel.ERROR, "error message a")
+        )
+
+        testServiceB.logSomething()
+        assertThat(log.entries).containsExactly(
+            LogEntry(logger(TestServiceA::class), LogLevel.TRACE, "trace message a"),
+            LogEntry(logger(TestServiceA::class), LogLevel.DEBUG, "debug message a"),
+            LogEntry(logger(TestServiceA::class), LogLevel.INFO, "info message a"),
+            LogEntry(logger(TestServiceA::class), LogLevel.WARN, "warn message a"),
+            LogEntry(logger(TestServiceA::class), LogLevel.ERROR, "error message a")
+        )
+
+        customLogger.trace("trace message c")
+        customLogger.debug("debug message c")
+        customLogger.info("info message c")
+        customLogger.warn("warn message c")
+        customLogger.error("error message c")
+
+        assertThat(log.entries).containsExactly(
+            LogEntry(logger(TestServiceA::class), LogLevel.TRACE, "trace message a"),
+            LogEntry(logger(TestServiceA::class), LogLevel.DEBUG, "debug message a"),
+            LogEntry(logger(TestServiceA::class), LogLevel.INFO, "info message a"),
+            LogEntry(logger(TestServiceA::class), LogLevel.WARN, "warn message a"),
+            LogEntry(logger(TestServiceA::class), LogLevel.ERROR, "error message a")
+        )
+    }
+
 }
 
 class TestServiceA {

--- a/logrecorder/pom.xml
+++ b/logrecorder/pom.xml
@@ -17,6 +17,7 @@
 		<module>logrecorder-api</module>
 		<module>logrecorder-assertions</module>
 		<module>logrecorder-logback</module>
+		<module>logrecorder-log4j</module>
 	</modules>
 
 	<dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
 		<kotlin.version>1.5.31</kotlin.version>
 		<dokka.version>1.5.31</dokka.version>
 		<logback.version>1.2.6</logback.version>
+		<log4j.version>2.14.1</log4j.version>
 		<slf4j.version>1.7.32</slf4j.version>
 	</properties>
 
@@ -99,6 +100,11 @@
 				<groupId>ch.qos.logback</groupId>
 				<artifactId>logback-classic</artifactId>
 				<version>${logback.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.logging.log4j</groupId>
+				<artifactId>log4j-core</artifactId>
+				<version>${log4j.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.assertj</groupId>


### PR DESCRIPTION
I implemented a logrecorder for log4j 2

it follows the implementation from logback

in logbackrecorder I added another testcase to have the same tests in log4jrecorder and logbackrecorder