### PR TITLE
fix issue when having a java project and log4j logger is init via log4j2.xml

### DIFF
--- a/logrecorder/logrecorder-log4j/src/main/kotlin/info/novatec/testit/logrecorder/log4j/Log4jLogRecorder.kt
+++ b/logrecorder/logrecorder-log4j/src/main/kotlin/info/novatec/testit/logrecorder/log4j/Log4jLogRecorder.kt
@@ -59,7 +59,8 @@ internal class Log4jLogRecorder(
             configuration.addLogger(loggerName, newLoggerConfig)
             newCreatedLogger = true
         } else {
-            loggerConfig.appenderRefs.add(appenderRef)
+            loggerConfig.addAppender(appender, null, null)
+            loggerConfig.level = Level.ALL
         }
         updateLoggerContext()
     }
@@ -71,7 +72,7 @@ internal class Log4jLogRecorder(
             configuration.removeLogger(loggerName)
         } else {
             val loggerConfig = getLoggerConfig()
-            loggerConfig.appenderRefs.remove(appenderRef)
+            loggerConfig.removeAppender(appender.name)
             loggerConfig.level = originalLoggerLevel
         }
         updateLoggerContext()


### PR DESCRIPTION
when a logger is init via log4j2.xml in a plain java project appenderRefs can't be added because it's a java.util.Array$ArrayList and method add is not supported (this problem does not happen when compiling with kotlin compiler)
therefore we add the appender alone

also the setting for the loglevel was missing