### PR TITLE
add @JvmStatic Annotation to avoid `.Companion.` in java classes

### DIFF
--- a/logrecorder/logrecorder-api/src/main/kotlin/info/novatec/testit/logrecorder/api/LogRecord.kt
+++ b/logrecorder/logrecorder-api/src/main/kotlin/info/novatec/testit/logrecorder/api/LogRecord.kt
@@ -86,6 +86,7 @@ interface LogRecord {
          */
         fun logger(clazz: KClass<*>): String = logger(clazz.java)
 
+        @JvmStatic
         fun logger(clazz: Class<*>): String = clazz.name
     }
 

--- a/logrecorder/logrecorder-assertions/src/main/kotlin/info/novatec/testit/logrecorder/assertion/LogRecordAssertion.kt
+++ b/logrecorder/logrecorder-assertions/src/main/kotlin/info/novatec/testit/logrecorder/assertion/LogRecordAssertion.kt
@@ -37,6 +37,7 @@ class LogRecordAssertion(
     }
 
     companion object {
+        @JvmStatic
         fun assertThat(logRecord: LogRecord, block: LogRecordAssertion.() -> Unit) {
             LogRecordAssertion(logRecord).apply(block).check()
         }


### PR DESCRIPTION
the JvmStatic annotation on companion methods forces the kotlin compiler to generate a second static method and then its usable without Companion in java classes