### PR TITLE
change default version for continuous releases

### DIFF
--- a/logrecorder/logrecorder-api/pom.xml
+++ b/logrecorder/logrecorder-api/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>info.novatec.testit</groupId>
 		<artifactId>logrecorder</artifactId>
-		<version>1.6.0-SNAPSHOT</version>
+		<version>0.0.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>logrecorder-api</artifactId>

--- a/logrecorder/logrecorder-assertions/pom.xml
+++ b/logrecorder/logrecorder-assertions/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>info.novatec.testit</groupId>
 		<artifactId>logrecorder</artifactId>
-		<version>1.6.0-SNAPSHOT</version>
+		<version>0.0.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>logrecorder-assertions</artifactId>

--- a/logrecorder/logrecorder-jul/pom.xml
+++ b/logrecorder/logrecorder-jul/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>info.novatec.testit</groupId>
 		<artifactId>logrecorder</artifactId>
-		<version>1.6.0-SNAPSHOT</version>
+		<version>0.0.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>logrecorder-jul</artifactId>

--- a/logrecorder/logrecorder-log4j/pom.xml
+++ b/logrecorder/logrecorder-log4j/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>info.novatec.testit</groupId>
 		<artifactId>logrecorder</artifactId>
-		<version>1.6.0-SNAPSHOT</version>
+		<version>0.0.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>logrecorder-log4j</artifactId>

--- a/logrecorder/logrecorder-logback/pom.xml
+++ b/logrecorder/logrecorder-logback/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>info.novatec.testit</groupId>
 		<artifactId>logrecorder</artifactId>
-		<version>1.6.0-SNAPSHOT</version>
+		<version>0.0.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>logrecorder-logback</artifactId>

--- a/logrecorder/pom.xml
+++ b/logrecorder/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>info.novatec.testit</groupId>
 		<artifactId>testutils</artifactId>
-		<version>1.6.0-SNAPSHOT</version>
+		<version>0.0.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>logrecorder</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>info.novatec.testit</groupId>
 	<artifactId>testutils</artifactId>
-	<version>1.6.0-SNAPSHOT</version>
+	<version>0.0.1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>testIT | TestUtils</name>


### PR DESCRIPTION
Since version numbers are set ad-hoc when releasing a new version, there is no reason to always increment the SNAPSHOT version.